### PR TITLE
fix(gamerepository): adjust alias from sql query

### DIFF
--- a/src/main/java/com/javacourse/dynamiclist/repositories/GameRepository.java
+++ b/src/main/java/com/javacourse/dynamiclist/repositories/GameRepository.java
@@ -13,10 +13,10 @@ public interface GameRepository extends JpaRepository<Game, Long> {
 			SELECT
 			    game.id,
 			    game.title,
-			    game.created_year AS `year`,
+			    game.created_year AS createdYear,
 			    game.img_url AS imgUrl,
 			    game.short_description AS shortDescription,
-			    game_category_assoc.position,
+			    game_category_assoc.position
 			FROM
 			    game
 			INNER JOIN


### PR DESCRIPTION
GameRepository

- Fix returned created year value when consuming find by category API
Related to Study-005